### PR TITLE
fix: Page height

### DIFF
--- a/src/containers/hotsite/styles/index.scss
+++ b/src/containers/hotsite/styles/index.scss
@@ -34,9 +34,9 @@ body, html, main, #root {
   .u-flex {
     align-items: center;
   }
-  &:after {
-    background-image: url(http://polishop.vteximg.com.br/arquivos/rumo-2030-bg-1.png);
-  }
+  // &:after {
+  //   background-image: url(http://polishop.vteximg.com.br/arquivos/rumo-2030-bg-1.png);
+  // }
 }
 
 .Intro-logo {

--- a/src/containers/hotsite/styles/utils.scss
+++ b/src/containers/hotsite/styles/utils.scss
@@ -121,7 +121,8 @@
 .wrapper {
   /* The height needs to be set to a fixed value for the effect to work.
    * 100vh is the full height of the viewport. */
-  height: 100vh;
+  height: auto;
+  min-height: 100vh;
   /* The scaling of the images would add a horizontal scrollbar, so disable x overflow. */
   overflow-x: hidden;
   /* Enable scrolling on the page. */

--- a/src/containers/streaming/index.css
+++ b/src/containers/streaming/index.css
@@ -137,7 +137,8 @@ body,
 }
 
 .wrapper {
-  height: 100vh;
+  height: auto;
+  min-height: 100vh;
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/src/containers/streaming/index.js
+++ b/src/containers/streaming/index.js
@@ -431,6 +431,7 @@ class Streaming extends Component {
     console.log("token", token);
 
     window.open(src, "_self");
+    return <></>;
 
     // return (
     //   <div className="streaming">


### PR DESCRIPTION
Esse PR faz algumas correções pontuais:

- Corrige o tamanho da página, que impedia de visualizar todo o conteúdo;
- Elimina uma imagem de background "perdida" que aparecia por baixo do botão "Entrar na LIVE";
- Corrige um erro que aparecia (ver imagem abaixo) entre o login e o redirect para a página da transmissão do evento.

![Screen Shot 2021-09-15 at 15 25 42](https://user-images.githubusercontent.com/5032844/133491011-80cbb25d-4b63-47d9-a004-cde0eeb91f30.png)

Quando o usuário está autenticado, o React tentava renderizar o componente `StreamScreen` mas essa função não possuía nenhum HTML para ser renderizado (comentado).